### PR TITLE
Fix score screen results

### DIFF
--- a/lib/screens/score/score_screen.dart
+++ b/lib/screens/score/score_screen.dart
@@ -37,23 +37,13 @@ class ScoreScreen extends StatelessWidget {
                     .copyWith(color: Colors.white),
               ),
               Spacer(),
-              if (_qnController.correctAns != null) ...[
-                Text(
-                  "${_qnController.correctAns}/${_qnController.questions.length}",
-                  style: Theme.of(context)
-                      .textTheme
-                      .headline4
-                      .copyWith(color: Colors.white),
-                ),
-              ] else ...[
-                Text(
-                  "0/${_qnController.questions.length}",
-                  style: Theme.of(context)
-                      .textTheme
-                      .headline4
-                      .copyWith(color: Colors.white),
-                ),
-              ],
+              Text(
+                "${_qnController.numOfCorrectAns}/${_qnController.questions.length}",
+                style: Theme.of(context)
+                    .textTheme
+                    .headline4
+                    .copyWith(color: Colors.white),
+              ),
               Spacer(flex: 3),
             ],
           )


### PR DESCRIPTION
## Summary
- fix incorrect score display in ScoreScreen

## Testing
- `flutter test` *(fails: Unable to 'pub upgrade' flutter tool)*

------
https://chatgpt.com/codex/tasks/task_e_687a0316079883259429551391a2ec10